### PR TITLE
Enable automatic class compilation and add tests

### DIFF
--- a/CompilationEngine.py
+++ b/CompilationEngine.py
@@ -21,6 +21,13 @@ class CompilationEngine:
         self.output_stream = output_stream
         self._indent_count = 0
 
+        # Prime the tokenizer and immediately compile the class so that
+        # users of this class only need to instantiate it in order to
+        # generate the output.
+        if self.tokenizer.has_more_tokens():
+            self.tokenizer.advance()
+            self.compile_class()
+
     def compile_class(self) -> None:
         self._write_outer_tag("class")
         self._write_token("KEYWORD")

--- a/JackCompiler.py
+++ b/JackCompiler.py
@@ -10,8 +10,6 @@ import sys
 import typing
 from CompilationEngine import CompilationEngine
 from JackTokenizer import JackTokenizer
-from SymbolTable import SymbolTable
-from VMWriter import VMWriter
 
 
 def compile_file(
@@ -24,10 +22,11 @@ def compile_file(
     """
 
     tokenizer = JackTokenizer(input_file)
-    vm_writer = VMWriter(output_file)
 
     # The constructor recursively compiles the entire class.
-    CompilationEngine(tokenizer, vm_writer)
+    # CompilationEngine currently outputs XML directly using the provided
+    # stream, so we pass the raw output file.
+    CompilationEngine(tokenizer, output_file)
 
 if "__main__" == __name__:
     # Parses the input path and calls compile_file on each input file.

--- a/JackTokenizer.py
+++ b/JackTokenizer.py
@@ -26,17 +26,6 @@ class JackTokenizer:
             tokens = re.findall(r"[{}\[\]()\.,;\+\-\*/&|<>=~]|\w+|\".*?\"", line)
             self._token_buffer.extend(tokens)
 
-    def _prepare_tokensss(self) -> None:
-        def remove_comments(line: str) -> str:
-            return re.sub(r"//.*|/\*.*?\*/", "", line, flags=re.DOTALL)
-
-        lines_no_comments = [remove_comments(line).strip() for line in self._lines]
-        cleaned_lines = filter(None, lines_no_comments)
-
-        for line in cleaned_lines:
-            tokens = re.findall(r"[{}\[\]()\.,;\+\-\*/&|<>=~]|\w+|\".*?\"", line)
-            for token in tokens:
-                self._token_buffer.append(token)
 
     def has_more_tokens(self) -> bool:
         return len(self._token_buffer) > 0

--- a/tests/test_jack_compiler.py
+++ b/tests/test_jack_compiler.py
@@ -1,0 +1,54 @@
+import sys, os, io
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from JackTokenizer import JackTokenizer
+from CompilationEngine import CompilationEngine
+
+
+def test_tokenizer_basic():
+    code = "class Main { function void main() { return; } }"
+    tokenizer = JackTokenizer(io.StringIO(code))
+    tokens = []
+    while tokenizer.has_more_tokens():
+        tokenizer.advance()
+        tokens.append(tokenizer.get_token_string())
+    assert tokens == [
+        "class", "Main", "{", "function", "void", "main", "(", ")",
+        "{", "return", ";", "}", "}"
+    ]
+
+
+def test_compile_basic_class():
+    code = "class Main { function void main() { return; } }"
+    tokenizer = JackTokenizer(io.StringIO(code))
+    output = io.StringIO()
+    CompilationEngine(tokenizer, output)
+    result = output.getvalue().strip().splitlines()
+    expected = [
+        "<class>",
+        "  <keyword> class </keyword>",
+        "  <identifier> Main </identifier>",
+        "  <symbol> { </symbol>",
+        "  <subroutineDec>",
+        "    <keyword> function </keyword>",
+        "    <keyword> void </keyword>",
+        "    <identifier> main </identifier>",
+        "    <symbol> ( </symbol>",
+        "    <parameterList>",
+        "      </parameterList>",
+        "    <symbol> ) </symbol>",
+        "    <subroutineBody>",
+        "      <symbol> { </symbol>",
+        "      <statements>",
+        "        <returnStatement>",
+        "          <keyword> return </keyword>",
+        "          <symbol> ; </symbol>",
+        "          </returnStatement>",
+        "        </statements>",
+        "      <symbol> } </symbol>",
+        "      </subroutineBody>",
+        "    </subroutineDec>",
+        "  <symbol> } </symbol>",
+        "  </class>",
+    ]
+    assert result == expected


### PR DESCRIPTION
## Summary
- parse the entire class when `CompilationEngine` is instantiated
- clean up tokenizer helpers
- simplify `JackCompiler` to pass raw output stream
- provide unit tests for tokenization and compilation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d98bd721c8332b399f97e2569e9bd