### PR TITLE
Fix CompilationEngine initialization with pre-advanced tokenizers

### DIFF
--- a/CompilationEngine.py
+++ b/CompilationEngine.py
@@ -23,9 +23,12 @@ class CompilationEngine:
 
         # Prime the tokenizer and immediately compile the class so that
         # users of this class only need to instantiate it in order to
-        # generate the output.
-        if self.tokenizer.has_more_tokens():
-            self.tokenizer.advance()
+        # generate the output. If the tokenizer has already been advanced
+        # before this constructor is called, we should not advance it again.
+        if getattr(self.tokenizer, "_current_token", None) is None:
+            if self.tokenizer.has_more_tokens():
+                self.tokenizer.advance()
+        if getattr(self.tokenizer, "_current_token", None) is not None:
             self.compile_class()
 
     def compile_class(self) -> None:

--- a/tests/test_jack_compiler.py
+++ b/tests/test_jack_compiler.py
@@ -52,3 +52,40 @@ def test_compile_basic_class():
         "  </class>",
     ]
     assert result == expected
+
+
+def test_compile_basic_class_pre_advanced():
+    code = "class Main { function void main() { return; } }"
+    tokenizer = JackTokenizer(io.StringIO(code))
+    tokenizer.advance()
+    output = io.StringIO()
+    CompilationEngine(tokenizer, output)
+    result = output.getvalue().strip().splitlines()
+    expected = [
+        "<class>",
+        "  <keyword> class </keyword>",
+        "  <identifier> Main </identifier>",
+        "  <symbol> { </symbol>",
+        "  <subroutineDec>",
+        "    <keyword> function </keyword>",
+        "    <keyword> void </keyword>",
+        "    <identifier> main </identifier>",
+        "    <symbol> ( </symbol>",
+        "    <parameterList>",
+        "      </parameterList>",
+        "    <symbol> ) </symbol>",
+        "    <subroutineBody>",
+        "      <symbol> { </symbol>",
+        "      <statements>",
+        "        <returnStatement>",
+        "          <keyword> return </keyword>",
+        "          <symbol> ; </symbol>",
+        "          </returnStatement>",
+        "        </statements>",
+        "      <symbol> } </symbol>",
+        "      </subroutineBody>",
+        "    </subroutineDec>",
+        "  <symbol> } </symbol>",
+        "  </class>",
+    ]
+    assert result == expected


### PR DESCRIPTION
## Summary
- handle tokenizers that have already been advanced in `CompilationEngine.__init__`
- add regression test for pre-advanced tokenizers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d9a3a466c833297bedd39bd5eb75b