### PR TITLE
Call _prepare_tokensss for tokenizer initialization

### DIFF
--- a/JackTokenizer.py
+++ b/JackTokenizer.py
@@ -9,9 +9,9 @@ class JackTokenizer:
         self._current_token = None
         self._current_token_type = None
         self._in_comment = False
-        self._prepare_tokens()
+        self._prepare_tokensss()
 
-    def _prepare_tokens(self) -> None:
+    def _prepare_tokensss(self) -> None:
         def remove_comments(text: str) -> str:
             text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
             text = re.sub(r"//.*", "", text)


### PR DESCRIPTION
## Summary
- swap `_prepare_tokens` call with `_prepare_tokensss`
- rename the method accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d9a488df483329afa95333d4d6fcf