### PR TITLE
Add VM code generation support

### DIFF
--- a/SymbolTable.py
+++ b/SymbolTable.py
@@ -67,17 +67,18 @@ class SymbolTable:
             self._sub_scope[name] = entry
 
     def var_count(self, kind: str) -> int:
-        """
-        Args:
-            kind (str): can be "STATIC", "FIELD", "ARG", "VAR".
+        """Returns how many identifiers of ``kind`` have been defined.
 
-        Returns:
-            int: the number of variables of the given kind already defined in 
-            the current scope.
+        In accordance with the nand2tetris specification, ``STATIC`` and
+        ``FIELD`` counters are maintained at the class level, while ``ARG`` and
+        ``VAR`` counters are reset for every subroutine.  Therefore this method
+        simply exposes the relevant counter value.
+
+        Args:
+            kind (str): ``STATIC``, ``FIELD``, ``ARG`` or ``VAR``.
         """
         kind = kind.upper()
-        return self._counters.get(kind, 0) if kind in self._SUB_KINDS else \
-               sum(s.kind == kind for s in self._class_scope.values())
+        return self._counters.get(kind, 0)
 
     def kind_of(self, name: str) -> str:
         """

--- a/VMWriter.py
+++ b/VMWriter.py
@@ -6,6 +6,7 @@ as allowed by the Creative Common Attribution-NonCommercial-ShareAlike 3.0
 Unported [License](https://creativecommons.org/licenses/by-nc-sa/3.0/).
 """
 import typing
+from typing import Iterable
 
 
 class VMWriter:

--- a/tests/test_jack_compiler.py
+++ b/tests/test_jack_compiler.py
@@ -25,30 +25,8 @@ def test_compile_basic_class():
     CompilationEngine(tokenizer, output)
     result = output.getvalue().strip().splitlines()
     expected = [
-        "<class>",
-        "  <keyword> class </keyword>",
-        "  <identifier> Main </identifier>",
-        "  <symbol> { </symbol>",
-        "  <subroutineDec>",
-        "    <keyword> function </keyword>",
-        "    <keyword> void </keyword>",
-        "    <identifier> main </identifier>",
-        "    <symbol> ( </symbol>",
-        "    <parameterList>",
-        "      </parameterList>",
-        "    <symbol> ) </symbol>",
-        "    <subroutineBody>",
-        "      <symbol> { </symbol>",
-        "      <statements>",
-        "        <returnStatement>",
-        "          <keyword> return </keyword>",
-        "          <symbol> ; </symbol>",
-        "          </returnStatement>",
-        "        </statements>",
-        "      <symbol> } </symbol>",
-        "      </subroutineBody>",
-        "    </subroutineDec>",
-        "  <symbol> } </symbol>",
-        "  </class>",
+        "function Main.main 0",
+        "push constant 0",
+        "return",
     ]
     assert result == expected


### PR DESCRIPTION
## Summary
- improve `var_count` in `SymbolTable` and document counters
- reimplement `CompilationEngine` to emit VM code via `VMWriter`
- adjust VMWriter typing imports
- update tests for VM output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d9a1ae7788332836b1b7e78f2e073